### PR TITLE
chore: remove unsafe-assign warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ const kSASTWarnings = [
   "unsafe-import",
   "unsafe-regex",
   "unsafe-stmt",
-  "unsafe-assign",
   "encoded-literal",
   "short-identifiers",
   "suspicious-literal",


### PR DESCRIPTION
👋
This PR remove unsafe-assign warning as it has been removed from js-x-ray in this PR: https://github.com/NodeSecure/js-x-ray/pull/57

<img width="449" alt="Capture d’écran 2023-02-05 à 12 36 56" src="https://user-images.githubusercontent.com/39910767/216816463-210bc901-e4cb-4eee-a80a-6d0bae7ab1ff.png">
